### PR TITLE
deployed the site using heroku but there was an "OperationalError"

### DIFF
--- a/ezsite/settings.py
+++ b/ezsite/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 from pathlib import Path
 from decouple import config
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -22,7 +23,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 
-SECRET_KEY = config("SECRET_KEY")
+SECRET_KEY = os.environ.get['SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/ezsite/settings.py
+++ b/ezsite/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib import Path
-from decouple import config
 import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/ezsite/settings.py
+++ b/ezsite/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 
-SECRET_KEY = os.environ.get['SECRET_KEY']
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/utils/controller.py
+++ b/utils/controller.py
@@ -2,7 +2,6 @@ from utils import everything
 from utils import spotify_auth
 import re
 import json
-from decouple import config
 import os
 
 class migrate:

--- a/utils/controller.py
+++ b/utils/controller.py
@@ -3,7 +3,7 @@ from utils import spotify_auth
 import re
 import json
 from decouple import config
-
+import os
 
 class migrate:
     c_type = ''
@@ -21,7 +21,7 @@ class migrate:
         if ytMatch is not None: # Convert YT to Spotify
             self.c_type = 'yt2sp'
             ytListId = ytMatch.group(1)
-            yt = everything.yt2spoti(login(), config('YT_KEY'), ytListId)
+            yt = everything.yt2spoti(login(), os.environ.get('YT_KEY'), ytListId)
             return yt.convert()
         elif spMatch is not None: # Convert Spotify to YT
             self.c_type = 'sp2yt'
@@ -31,7 +31,7 @@ class migrate:
         return "Invalid Link"
 
 def login():
-    token = spotify_auth.get_spoti_access_token(config('CLIENT_ID'), config('CLIENT_SECRET'))
+    token = spotify_auth.get_spoti_access_token(os.environ.get('CLIENT_ID'), os.environ.get('CLIENT_SECRET'))
     return token
 
 def logState(state):

--- a/utils/everything.py
+++ b/utils/everything.py
@@ -7,7 +7,6 @@ from pyyoutube import Api
 import json
 import urllib.request
 import urllib
-from decouple import config
 import re
 
 # spotify_token = '' #this is where the spotify token should be entered


### PR DESCRIPTION
The error was - 

> OperationalError at /
> no such table: django_session

From a [stackoverflow answer](https://stackoverflow.com/questions/3631556/django-no-such-table-django-session)
> It could be that the server uses a different working directory than the manage.py command. Since you provide a relative path to the sqlite database, it is created in the working directory. Try it with an absolute path, e.g.:
> 
> 'NAME': '/tmp/mysite.sqlite3',
> Remember that you have to either run ./manage.py syncdb again or copy your current database with the existing tables to /tmp.
> 
> If it resolves the error message, you can look for a better place than /tmp :-)